### PR TITLE
Fix: Ensure All Tensors and Models are on the Same Device

### DIFF
--- a/uncertaintyplayground/models/svgp_model.py
+++ b/uncertaintyplayground/models/svgp_model.py
@@ -11,22 +11,25 @@ class SVGP(gpytorch.models.ApproximateGP):
     Args:
         inducing_points (torch.Tensor): Inducing points tensor.
         dtype (torch.dtype, optional): Data type of the model. Defaults to torch.float32.
-
+        device (torch.device): Device can be specified to the desired `cpu` or `cuda` for GPU
+    
     Attributes:
         mean_module (gpytorch.means.ConstantMean): Constant mean module.
         covar_module (gpytorch.kernels.ScaleKernel): Scaled RBF kernel.
     """
 
-    def __init__(self, inducing_points, dtype=torch.float32):
+    def __init__(self, inducing_points, dtype=torch.float32, device = None):
+        self.device = device
+        self.inducing_points = inducing_points.to(device = self.device)
         variational_distribution = gpytorch.variational.CholeskyVariationalDistribution(
-            inducing_points.size(0), dtype=dtype
+            self.inducing_points.size(0), dtype=dtype
         )
         variational_strategy = gpytorch.variational.VariationalStrategy(
             self,
-            inducing_points,
+            self.inducing_points,
             variational_distribution,
-            learn_inducing_locations=True,
-        ).to(dtype)
+            learn_inducing_locations=True
+        ).to(dtype = dtype)
 
         super().__init__(variational_strategy)
         self.mean_module = gpytorch.means.ConstantMean(dtype=dtype)
@@ -43,6 +46,7 @@ class SVGP(gpytorch.models.ApproximateGP):
         Returns:
             gpytorch.distributions.MultivariateNormal: Multivariate normal distribution with the given mean and covariance.
         """
+        x = x.to(device = self.device)
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)
         return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)

--- a/uncertaintyplayground/tests/test_base_trainer.py
+++ b/uncertaintyplayground/tests/test_base_trainer.py
@@ -1,0 +1,46 @@
+import unittest
+import torch
+from uncertaintyplayground.trainers.base_trainer import BaseTrainer
+
+class TestBaseTrainer(unittest.TestCase):
+    """
+    Unit test suite for the BaseTrainer class.
+
+    This class contains a series of methods to test the functionalities of BaseTrainer, including preparing the data loader.
+
+    Attributes:
+        X_train (torch.Tensor): A tensor of feature vectors for the training data.
+        y_train (torch.Tensor): A tensor of target values for the training data.
+        sample_weights_train (torch.Tensor): A tensor of sample weights for the training data.
+        trainer (BaseTrainer): The BaseTrainer instance to test.
+    """
+
+    def setUp(self):
+        """
+        Setup function that runs before each test method.
+
+        This method generates random data for the tests and initializes an instance of BaseTrainer.
+        """
+        self.X = torch.randn(100, 20)
+        self.y = torch.randn(100)
+        self.batch_size = 10
+        self.test_size = 0.2
+        self.sample_weights = torch.randn(100)
+        self.trainer = BaseTrainer(self.X, self.y, self.sample_weights, batch_size=self.batch_size, test_size= self.test_size)
+
+    def test_prepare_dataloader(self):
+        """
+        Tests the prepare_dataloader method of the BaseTrainer class.
+
+        This test prepares the data loader and checks that it has the correct length and batch size.
+        """
+        self.trainer.prepare_dataloader()
+        self.assertEqual(len(self.trainer.train_loader) * self.batch_size, len(self.trainer.X_train))
+
+        for batch in self.trainer.train_loader:
+            self.assertEqual(batch[0].shape, (self.batch_size, self.X.shape[1]))
+            self.assertEqual(batch[1].shape, (self.batch_size,))
+            self.assertEqual(batch[2].shape, (self.batch_size,))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uncertaintyplayground/tests/test_svgp_model.py
+++ b/uncertaintyplayground/tests/test_svgp_model.py
@@ -14,7 +14,8 @@ class TestSVGP(unittest.TestCase):
         """
         self.inducing_points = torch.rand((10, 2))
         self.dtype = torch.float32
-        self.svgp = SVGP(self.inducing_points, self.dtype)
+        self.device = None
+        self.svgp = SVGP(self.inducing_points, dtype = self.dtype,  device = self.device)
 
     def test_init(self):
         """

--- a/uncertaintyplayground/trainers/base_trainer.py
+++ b/uncertaintyplayground/trainers/base_trainer.py
@@ -21,6 +21,8 @@ class BaseTrainer:
         use_scheduler (bool): Whether to use a learning rate scheduler (`not yet fully supported`).
         patience (int): Number of consecutive epochs with no improvement after which training will be stopped.
         dtype (torch.dtype): Data type to use for the tensors.
+        device (torch.device): Device can be specified to the desired `cpu` or `cuda` for GPU (else if set to `None`, then GPU if available, otherwise CPU).
+        multi_cpu_dataloader (bool): Use multiple CPUs for data loading or pass everything onto the GPU.
 
     Attributes:
         X (torch.Tensor): Input data tensor.
@@ -34,7 +36,6 @@ class BaseTrainer:
         lr (float): Learning rate for the optimizer.
         patience (int): Number of consecutive epochs with no improvement after which training will be stopped.
         dtype (torch.dtype): Data type of the tensors.
-        device (torch.device): Device (GPU if available, otherwise CPU).
         train_loader (torch.utils.data.DataLoader): DataLoader for training data.
     """
 
@@ -51,7 +52,9 @@ class BaseTrainer:
             lr=0.01,
             use_scheduler=False,
             patience=10,
-            dtype=torch.float32
+            dtype=torch.float32,
+            device = None,
+            multi_cpu_dataloader = True
     ):
         self.X = X
         self.y = y
@@ -72,7 +75,11 @@ class BaseTrainer:
 
         # Choose device (GPU if available, otherwise CPU)
         self.device = torch.device(
-            "cuda" if torch.cuda.is_available() else "cpu")
+            device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu")
+        )
+
+        # Choose whether to use multiple CPUs for data loading
+        self.multi_cpu_dataloader = multi_cpu_dataloader
 
         # Convert input tensors to the correct type
         self.prepare_inputs()
@@ -89,7 +96,7 @@ class BaseTrainer:
         """
         # Convert X to a tensor if it's a numpy array
         if isinstance(self.X, np.ndarray):
-            self.X = torch.from_numpy(self.X).to(self.dtype)
+            self.X = torch.from_numpy(self.X).to(dtype=self.dtype)
 
         # Convert y to a tensor if it's a list or numpy array
         if isinstance(self.y, (list, np.ndarray)):
@@ -101,7 +108,7 @@ class BaseTrainer:
                 self.sample_weights = torch.tensor(
                     self.sample_weights, dtype=self.dtype)
 
-    def split_data(self, test_size=0.2):
+    def split_data(self):
         """
         Split the data into training and validation sets.
 
@@ -113,7 +120,7 @@ class BaseTrainer:
 
         self.X_train, self.X_val, self.y_train, self.y_val, self.sample_weights_train, self.sample_weights_val = \
             train_test_split(self.X, self.y, self.sample_weights,
-                             test_size=test_size, random_state=self.random_state)
+                             test_size=self.test_size, random_state=self.random_state)
 
     def custom_lr_scheduler(self, epoch):
         """
@@ -131,13 +138,16 @@ class BaseTrainer:
             return 0.2 / self.lr
 
     def prepare_dataloader(self):
-        """
-        Prepare the DataLoader for training data.
-        """
-        # Use all available CPU cores or default to 1 if not detected
-        num_workers = os.cpu_count() - 1 or 1
-        train_dataset = TensorDataset(
-            self.X_train, self.y_train, self.sample_weights_train)
-        self.train_loader = DataLoader(
-            train_dataset, batch_size=self.batch_size, shuffle=False, num_workers=num_workers, pin_memory=True
-        )
+            """
+            Prepare the DataLoader for training data.
+            """
+            # Use all available CPU cores or default to 1 if not detected
+            if self.multi_cpu_dataloader:
+                num_workers = os.cpu_count() - 1 or 1
+            else:
+                num_workers = 0
+            train_dataset = TensorDataset(
+                self.X_train, self.y_train, self.sample_weights_train)
+            self.train_loader = DataLoader(
+                train_dataset, batch_size=self.batch_size, shuffle=False, num_workers=num_workers, pin_memory=True)
+

--- a/uncertaintyplayground/trainers/mdn_trainer.py
+++ b/uncertaintyplayground/trainers/mdn_trainer.py
@@ -25,11 +25,13 @@ class MDNTrainer(BaseTrainer):
         super().__init__(*args, **kwargs)
         self.n_gaussians = n_gaussians
 
-        self.model = MDN(input_dim=self.X.shape[1], n_gaussians=self.n_gaussians, dense1_units = dense1_units).to(self.device)
+        self.model = MDN(input_dim=self.X.shape[1], n_gaussians=self.n_gaussians, dense1_units = dense1_units).to(device = self.device)
         if self.dtype == torch.float64:
             self.model = self.model.double()  # Convert model parameters to float64
         optimizer_fn = getattr(torch.optim, self.optimizer_fn_name)
         self.optimizer = optimizer_fn(self.model.parameters(), lr=self.lr)
+        print(f"Model device: {next(self.model.parameters()).device}")
+        print(f"Data device: {next(iter(self.train_loader))[0].device}")
 
     def train(self):
         """


### PR DESCRIPTION
Resolve the error on some devices resulting from `SparseGPTrainer.train()` where:
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument tensors in method wrapper_CUDA_cat)
```