### PR TITLE
Add type hints for all existing modules

### DIFF
--- a/uncertaintyplayground/predplot/mdn_predplot.py
+++ b/uncertaintyplayground/predplot/mdn_predplot.py
@@ -1,9 +1,20 @@
 import seaborn as sns
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import warnings
+from typing import Optional, Union, List
+import torch
+from trainers.mdn_trainer import MDNTrainer
 
-def compare_distributions_mdn(trainer, x_instance, y_actual=None, num_samples=10000, ax=None, dtype=np.float32):
+def compare_distributions_mdn(
+    trainer: MDNTrainer,
+    x_instance: Union[np.ndarray, 'torch.Tensor'],
+    y_actual: Optional[Union[float, np.ndarray]] = None,
+    num_samples: int = 10000,
+    ax: Optional['matplotlib.axes.Axes'] = None,
+    dtype: np.dtype = np.float32
+) -> None:
     """
     Compare the actual and predicted outcome value/distributions for the MDN model.
 

--- a/uncertaintyplayground/predplot/mdn_predplot.py
+++ b/uncertaintyplayground/predplot/mdn_predplot.py
@@ -5,7 +5,7 @@ import numpy as np
 import warnings
 from typing import Optional, Union, List
 import torch
-from trainers.mdn_trainer import MDNTrainer
+from uncertaintyplayground.trainers.mdn_trainer import MDNTrainer
 
 def compare_distributions_mdn(
     trainer: MDNTrainer,

--- a/uncertaintyplayground/predplot/svgp_predplot.py
+++ b/uncertaintyplayground/predplot/svgp_predplot.py
@@ -1,8 +1,18 @@
 import seaborn as sns
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+from typing import Optional, Union
+from trainers.svgp_trainer import SparseGPTrainer
 
-def compare_distributions_svgpr(trainer, x_instance, y_actual=None, num_samples=10000, ax=None, dtype=np.float32):
+def compare_distributions_svgpr(
+    trainer: SparseGPTrainer,
+    x_instance: np.ndarray,
+    y_actual: Optional[Union[float, np.ndarray]] = None,
+    num_samples: int = 10000,
+    ax: Optional['matplotlib.axes.Axes'] = None,
+    dtype: np.dtype = np.float32
+) -> None:
     """
     Compare the actual and predicted outcome value/distributions for the SVGPR model.
 

--- a/uncertaintyplayground/predplot/svgp_predplot.py
+++ b/uncertaintyplayground/predplot/svgp_predplot.py
@@ -3,7 +3,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 from typing import Optional, Union
-from trainers.svgp_trainer import SparseGPTrainer
+from uncertaintyplayground.trainers.svgp_trainer import SparseGPTrainer
 
 def compare_distributions_svgpr(
     trainer: SparseGPTrainer,


### PR DESCRIPTION
Add type hints using `typing` and then if necessary, add `typed.py` 